### PR TITLE
Fix inaccurate client varbits read on login

### DIFF
--- a/src/main/java/com/scrollboxinfo/ScrollBoxInfoPlugin.java
+++ b/src/main/java/com/scrollboxinfo/ScrollBoxInfoPlugin.java
@@ -665,6 +665,10 @@ public class ScrollBoxInfoPlugin extends Plugin
 	@Subscribe
 	public void onProfileChanged(ProfileChanged event)
 	{
+		refreshInfoboxes();
+	}
+
+	private void refreshInfoboxes() {
 		removeAllInfoboxes();
 
 		clientThread.invokeLater(() ->
@@ -678,6 +682,15 @@ public class ScrollBoxInfoPlugin extends Plugin
 				checkAndDisplayInfobox(tier, count, cap);
 			}
 		});
+	}
+
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged varbitChanged)
+	{
+		if (StackLimitCalculator.SCROLL_VARBITS.contains(varbitChanged.getVarbitId()))
+		{
+			refreshInfoboxes();
+		}
 	}
 
 	@Subscribe

--- a/src/main/java/com/scrollboxinfo/StackLimitCalculator.java
+++ b/src/main/java/com/scrollboxinfo/StackLimitCalculator.java
@@ -2,6 +2,9 @@ package com.scrollboxinfo;
 
 import net.runelite.api.Client;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class StackLimitCalculator
 {
     public static final int SCROLL_CASE_BEGINNER_MINOR = 16565;
@@ -17,6 +20,22 @@ public class StackLimitCalculator
     public static final int SCROLL_CASE_MASTER_MINOR = 16593;
     public static final int SCROLL_CASE_MASTER_MAJOR = 16594;
     public static final int SCROLL_CASE_MIMIC = 16595;
+
+    public static final List<Integer> SCROLL_VARBITS = Arrays.asList(
+        SCROLL_CASE_BEGINNER_MINOR,
+        SCROLL_CASE_BEGINNER_MAJOR,
+        SCROLL_CASE_EASY_MINOR,
+        SCROLL_CASE_EASY_MAJOR,
+        SCROLL_CASE_MEDIUM_MINOR,
+        SCROLL_CASE_MEDIUM_MAJOR,
+        SCROLL_CASE_HARD_MINOR,
+        SCROLL_CASE_HARD_MAJOR,
+        SCROLL_CASE_ELITE_MINOR,
+        SCROLL_CASE_ELITE_MAJOR,
+        SCROLL_CASE_MASTER_MINOR,
+        SCROLL_CASE_MASTER_MAJOR,
+        SCROLL_CASE_MIMIC
+    );
     private static final int BASE_CLUE_CAP = 2;
 
     public static int getStackLimit(ClueTier tier, Client client)


### PR DESCRIPTION
Fixes https://github.com/IEarnSolo/scrollboxcounter/issues/6

The client.getVarbitValue call in StackLimitCalculator was reading 0 values on login, resulting in invalid "full" infoboxes appearing because it thinks your cap is 2, even though it may be higher. I confirmed this with logs:
> 2026-04-25 14:43:22 CDT [Client] INFO  c.scrollboxinfo.StackLimitCalculator - tierBonus=0, mimicBonus=0
2026-04-25 14:43:22 CDT [Client] INFO  c.scrollboxinfo.ScrollBoxInfoPlugin - GameState.LOGGED_IN tier=MEDIUM, count=3, cap=2

 This PR addresses this invalid state read by subscribing to onVarbitChanged and refreshing the infoboxes if one of the scroll case varbits is changed. Testing locally and working.
 
Here's another video demonstration of the problem, which this PR fixes:


https://github.com/user-attachments/assets/2d7395fc-8208-4605-bf58-ea7c63486128

